### PR TITLE
Fix UV index color classification

### DIFF
--- a/assets/scripts/weather-dashboard.js
+++ b/assets/scripts/weather-dashboard.js
@@ -256,21 +256,16 @@ function fNewDay(pContainer, pDate, pTempImg, pTemp, pDescTemp, pWind, pHum, pUV
 }
 
 function fFindUVColor(pUVIndex) {
-    pUVIndex = pUVIndex + 1;
-    pUVIndex = pUVIndex - 1;
-
-    let uvColor = "";
-    if (pUVIndex >= 8) {
-        uvColor = "uvRed";
-    } else {
-        if (pUVIndex >= 6) {
-            uvColor = "uvYellow";
-        } else {
-            uvColor = "uvGreen";
-        }
+    const uvValue = Number(pUVIndex);
+    if (Number.isNaN(uvValue)) {
+        return "uvGreen";
     }
-
-    return uvColor;
+    if (uvValue >= 8) {
+        return "uvRed";
+    } else if (uvValue >= 6) {
+        return "uvYellow";
+    }
+    return "uvGreen";
 }
 
 


### PR DESCRIPTION
## Summary
- handle string UV index values correctly
- simplify UV index color calculation

## Testing
- `npm test` *(fails: enoent)*
- `node -e "function fFindUVColor(pUVIndex){const uvValue=Number(pUVIndex);if(Number.isNaN(uvValue)){return 'uvGreen';}if(uvValue>=8){return 'uvRed';} else if(uvValue>=6){return 'uvYellow';} return 'uvGreen';} console.log(fFindUVColor('7')); console.log(fFindUVColor('1')); console.log(fFindUVColor('9')); console.log(fFindUVColor('foo'));"`


------
https://chatgpt.com/codex/tasks/task_e_6895eb67c68883319890ef20f02cddf9