### PR TITLE
Fix project link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## _Plan your week in advance_
 
 Our app is deployed
-at [https://giannifontanot.github.io/Weather-Dashboard/](https://giannifontanot.github.io/Wheather-Dashboard/)
+at [https://giannifontanot.github.io/Wheather-Dashboard/](https://giannifontanot.github.io/Wheather-Dashboard/)
 
 Weather Dashboard is a tiny app that shows the weather for the next 5 days.
 


### PR DESCRIPTION
## Summary
- fix README hyperlink to point to the correct Wheather-Dashboard page

## Testing
- `npm test` *(fails: could not read package.json)*
- `curl -I https://giannifontanot.github.io/Wheather-Dashboard/` *(403)*

------
https://chatgpt.com/codex/tasks/task_e_6895ecec12ec833187ab8fa38f95f832