### PR TITLE
Fix typo in weather dashboard comment

### DIFF
--- a/assets/scripts/weather-dashboard.js
+++ b/assets/scripts/weather-dashboard.js
@@ -12,7 +12,7 @@ submitEl.addEventListener('click', fGetWeather);
 cityEl.addEventListener('click', fDeleteCityValue);
 
 
-// Fill CITY BUTTONS fron Local Storage
+// Fill CITY BUTTONS from Local Storage
 function fFillButtonsList() {
     console.log('fFillButtonsList');
     if ((localStorage.getItem('buttonsJSON'))) {


### PR DESCRIPTION
## Summary
- fix typo in comment when filling city buttons from Local Storage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895ec8740e08331a6930c614be083f1